### PR TITLE
ci: hourly GitHub Actions cron to tighten request-lifecycle SLAs (Vercel Hobby workaround)

### DIFF
--- a/.github/workflows/cron-sla.yml
+++ b/.github/workflows/cron-sla.yml
@@ -1,0 +1,64 @@
+# Sub-daily cron triggers for time-sensitive SLAs.
+#
+# WHY: Vercel Hobby crons fire only once per day, so the urgent "Consultation
+# ponctuelle rapide" accept timeout (12h) and the 24h take-charge reminder can
+# lag up to ~24h. GitHub Actions runs hourly and pings the SAME CRON_SECRET-
+# protected endpoints more often, tightening detection to ~1h. The Vercel daily
+# crons stay in place as a backup — the jobs are idempotent (atomic claim / dedup
+# flags), so triggering them from both places is safe.
+#
+# SETUP (one-time):
+#   1. Add a repo Actions secret CRON_SECRET equal to the Vercel env CRON_SECRET:
+#        gh secret set CRON_SECRET           (paste the value when prompted)
+#      or via GitHub → Settings → Secrets and variables → Actions → New secret.
+#   2. (Optional) If you use a custom production domain, add a repo VARIABLE
+#      CRON_BASE_URL (e.g. https://jechemine.ca). Otherwise it defaults to the
+#      Vercel production alias below.
+#
+# NOTES:
+#   - Scheduled workflows run ONLY from the default branch (main) — this must be
+#     merged to main to activate.
+#   - GitHub may delay a scheduled run by a few minutes (or skip it under heavy
+#     load); that's fine for a 12h/24h SLA, and a missed run is caught by the next
+#     one (the jobs are idempotent).
+name: cron-sla
+
+on:
+  schedule:
+    - cron: "0 * * * *" # hourly (UTC). Change to "0 */2 * * *" etc. for fewer runs.
+  workflow_dispatch: {} # manual trigger for testing
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cron-sla
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ vars.CRON_BASE_URL || 'https://cheminement.vercel.app' }}
+      CRON_SECRET: ${{ secrets.CRON_SECRET }}
+    steps:
+      - name: Guard — secret present
+        run: |
+          if [ -z "$CRON_SECRET" ]; then
+            echo "::error::CRON_SECRET repo secret is not set. Add it with the same value as the Vercel env CRON_SECRET."
+            exit 1
+          fi
+
+      - name: Proposal timeouts (hard accept SLA — 24h regular / 12h urgent)
+        run: |
+          curl -fsS --retry 2 --max-time 60 -X GET \
+            "$BASE_URL/api/cron/proposal-timeouts" \
+            -H "Authorization: Bearer $CRON_SECRET"
+          echo
+
+      - name: Unscheduled-match reminders (soft take-charge SLA — 24h)
+        run: |
+          curl -fsS --retry 2 --max-time 60 -X GET \
+            "$BASE_URL/api/cron/unscheduled-match-reminders" \
+            -H "Authorization: Bearer $CRON_SECRET"
+          echo

--- a/.github/workflows/cron-sla.yml
+++ b/.github/workflows/cron-sla.yml
@@ -11,9 +11,11 @@
 #   1. Add a repo Actions secret CRON_SECRET equal to the Vercel env CRON_SECRET:
 #        gh secret set CRON_SECRET           (paste the value when prompted)
 #      or via GitHub → Settings → Secrets and variables → Actions → New secret.
-#   2. (Optional) If you use a custom production domain, add a repo VARIABLE
-#      CRON_BASE_URL (e.g. https://jechemine.ca). Otherwise it defaults to the
-#      Vercel production alias below.
+#   2. (Optional) Override the target host with a repo VARIABLE CRON_BASE_URL.
+#      Default is the canonical production domain below. NOTE: target the exact
+#      host that serves the API WITHOUT a redirect — the apex jechemine.ca
+#      307-redirects to www.jechemine.ca, and a cross-host redirect drops the
+#      Authorization header, so use www.jechemine.ca (or cheminement-b77i.vercel.app).
 #
 # NOTES:
 #   - Scheduled workflows run ONLY from the default branch (main) — this must be
@@ -39,7 +41,7 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     env:
-      BASE_URL: ${{ vars.CRON_BASE_URL || 'https://cheminement.vercel.app' }}
+      BASE_URL: ${{ vars.CRON_BASE_URL || 'https://www.jechemine.ca' }}
       CRON_SECRET: ${{ secrets.CRON_SECRET }}
     steps:
       - name: Guard — secret present


### PR DESCRIPTION
## What
Adds `.github/workflows/cron-sla.yml` — an **hourly** GitHub Actions job that triggers the time-sensitive cron endpoints, working around the Vercel **Hobby** limit (daily crons only).

## Why
The §3 request lifecycle uses a hard accept timeout of **24h (regular) / 12h (urgent « Consultation ponctuelle rapide »)** and a soft **24h** take-charge reminder. On Hobby the daily cron detects these up to ~24h late. Pinging the endpoints hourly tightens detection to ~1h — no Vercel upgrade needed.

## How
- Hourly `schedule` + `workflow_dispatch` (manual test button).
- `curl`s `/api/cron/proposal-timeouts` and `/api/cron/unscheduled-match-reminders` with `Authorization: Bearer ${{ secrets.CRON_SECRET }}`.
- Jobs are idempotent (atomic claim / dedup flags) → safe alongside the existing Vercel daily crons, which stay as a backup.
- Base URL defaults to the Vercel prod alias; override with repo **variable** `CRON_BASE_URL` if you use a custom domain (e.g. jechemine.ca).

## Activation (required)
1. Add repo **secret** `CRON_SECRET` = the Vercel env `CRON_SECRET` value:
   - `gh secret set CRON_SECRET`  (or GitHub → Settings → Secrets and variables → Actions)
2. **Merge to `main`** — scheduled workflows only run from the default branch.
3. Test immediately via **Actions → cron-sla → Run workflow**.

> Note: GitHub may delay a scheduled run by a few minutes; a missed run is caught by the next one. This works against current production today and automatically picks up the new 24h/12h logic once the Section 2/3 changes are deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
