### PR TITLE
feat: flag « Refusé 2× — à revérifier » dans la file admin (§3.1)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -968,6 +968,8 @@
     "routingRefused": "Refused",
     "routingAwaitingAdmin": "Needs manual match",
     "attemptsLabel": "Attempts: {n}",
+    "refusedTwiceFlag": "Refused 2× — re-verify",
+    "refusedTwiceHint": "Refused or ignored by 2 professionals. Re-check the request (missing or inaccurate info), and contact the client or other professionals before reassigning.",
     "filterAll": "All",
     "scheduleAction": "Set appointment",
     "scheduleTitle": "Set an appointment",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -968,6 +968,8 @@
     "routingRefused": "Refusé",
     "routingAwaitingAdmin": "À jumeler",
     "attemptsLabel": "Tentatives : {n}",
+    "refusedTwiceFlag": "Refusé 2× — à revérifier",
+    "refusedTwiceHint": "Refusé ou ignoré par 2 professionnels. Vérifiez la demande (informations manquantes ou inexactes) et contactez le client ou d'autres professionnels avant de réassigner.",
     "filterAll": "Toutes",
     "scheduleAction": "Fixer un RDV",
     "scheduleTitle": "Fixer un rendez-vous",

--- a/src/components/admin/RequestsQueueTable.tsx
+++ b/src/components/admin/RequestsQueueTable.tsx
@@ -7,6 +7,7 @@ import {
   Trash2,
   UserCheck,
   CalendarPlus,
+  Flag,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -533,7 +534,7 @@ export default function RequestsQueueTable({
                     {new Date(r.createdAt).toLocaleString()}
                   </TableCell>
                   <TableCell>
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
                       <span>{r.clientName}</span>
                       {r.isEmergency ? (
                         <span
@@ -549,6 +550,18 @@ export default function RequestsQueueTable({
                           title={t("returningClientHint")}
                         >
                           {t("returningClient")}
+                        </span>
+                      ) : null}
+                      {/* §3.1: dossier refused/ignored by 2 pros (cascade
+                          exhausted) — flag the admin to re-verify the request. */}
+                      {typeof r.cascadeAttempts === "number" &&
+                      r.cascadeAttempts >= 2 ? (
+                        <span
+                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-red-600 text-white dark:bg-red-700"
+                          title={t("refusedTwiceHint")}
+                        >
+                          <Flag className="h-3 w-3" />
+                          {t("refusedTwiceFlag")}
                         </span>
                       ) : null}
                     </div>


### PR DESCRIPTION
Implements the remaining piece of client spec **§3.1**.

The 24h/12h hard timeout, refuse-or-timeout re-injection (excluding refused pros), 2-failure → `awaiting_admin` return to "Demande de service", and admin manual-assign / push-to-Liste-Générale were already shipped. This adds the explicit **flag**:

- A red **« Refusé 2× — à revérifier »** badge (Flag icon) next to the client name in the shared admin queue when `cascadeAttempts >= 2`.
- Tooltip: re-check the request (missing/inaccurate info), contact the client or other professionals before reassigning.
- Bilingual (`AdminServiceRequests.refusedTwiceFlag` / `refusedTwiceHint`).

Verified: tsc 0 · ESLint 0 · 163/163 vitest · i18n EN+FR lockstep. Admin-only UI; no schema/API change (`cascadeAttempts` already serialized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
