### PR TITLE
feat: lien « Conditions d'utilisation » dans le pied de page de chaque email

### DIFF
--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -456,6 +456,9 @@ const createFooter = (branding?: IEmailBranding, lang: "fr" | "en" = "fr"): stri
   const allRights = lang === "fr" ? "Tous droits réservés." : "All rights reserved.";
   const visitSite = lang === "fr" ? "Visiter notre site web" : "Visit our website";
   const contactSupport = lang === "fr" ? "Contacter le soutien" : "Contact support";
+  // Link to the Terms of Use in the footer of every platform email (client req).
+  const termsLabel =
+    lang === "fr" ? "Conditions d'utilisation" : "Terms of Use";
 
   return `
     <div class="footer">
@@ -465,6 +468,8 @@ const createFooter = (branding?: IEmailBranding, lang: "fr" | "en" = "fr"): stri
         <a href="${url}" style="color: ${primaryColor};">${visitSite}</a>
         &nbsp;·&nbsp;
         <a href="mailto:${supportEmail}" style="color: ${primaryColor};">${contactSupport}</a>
+        &nbsp;·&nbsp;
+        <a href="${url}/terms" style="color: ${primaryColor};">${termsLabel}</a>
       </p>
     </div>
   `;
@@ -571,10 +576,16 @@ const buildEmailHtml = (options: EmailTemplateOptions): string => {
 
 const buildEmailText = (sections: string[], lang: "fr" | "en" = "fr"): string => {
   const supportEmail = process.env.SUPPORT_EMAIL || "support@jechemine.ca";
+  const url = process.env.NEXTAUTH_URL || "";
+  // Terms-of-Use link in the footer of every platform email (client req).
+  const termsLine =
+    lang === "fr"
+      ? `Conditions d'utilisation : ${url}/terms`
+      : `Terms of Use: ${url}/terms`;
   const copyright =
     lang === "fr"
-      ? `© ${new Date().getFullYear()} Je chemine. Tous droits réservés.\nSoutien : ${supportEmail}`
-      : `© ${new Date().getFullYear()} Je chemine. All rights reserved.\nSupport: ${supportEmail}`;
+      ? `© ${new Date().getFullYear()} Je chemine. Tous droits réservés.\nSoutien : ${supportEmail}\n${termsLine}`
+      : `© ${new Date().getFullYear()} Je chemine. All rights reserved.\nSupport: ${supportEmail}\n${termsLine}`;
   return sections.filter(Boolean).join("\n\n") + `\n\n${copyright}`;
 };
 


### PR DESCRIPTION
Client request: add a link to the Terms of Use at the bottom of **every** email the platform sends.

## How
- Added the link in the **shared** email footer used by all emails:
  - `createFooter` (HTML) → a third footer link `Conditions d'utilisation` → `${NEXTAUTH_URL}/terms`.
  - `buildEmailText` (plaintext) → a `Conditions d'utilisation : …/terms` line in the footer.
- Bilingual (FR/EN), matching the recipient's locale.

## Coverage
Verified all 49 platform emails build their HTML via `buildEmailHtml` (→ `createFooter`), and no API route sends custom email HTML (only `notifications.ts` + `email-transport.ts` touch email). So **every** email gets the link automatically.

## Verification
tsc 0 · ESLint 0 · 172/172 vitest. Link resolves to the public /terms page (now the section-based, admin-editable doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
