### PR TITLE
feat(general pool): admin status-filter parity + pro 'Liste Générale' access

### DIFF
--- a/src/app/(privilaged)/admin/dashboard/general-pool/page.tsx
+++ b/src/app/(privilaged)/admin/dashboard/general-pool/page.tsx
@@ -14,6 +14,7 @@ export default function AdminGeneralPoolPage() {
       fetchUrl="/api/admin/general-pool"
       titleKey="poolTitle"
       subtitleKey="poolSubtitle"
+      enableStatusFilter
     />
   );
 }

--- a/src/app/(privilaged)/professional/dashboard/proposals/page.tsx
+++ b/src/app/(privilaged)/professional/dashboard/proposals/page.tsx
@@ -236,6 +236,21 @@ export default function ProposalsPage() {
     fetchAllAppointments();
   }, [fetchAllAppointments]);
 
+  // Deep-link support: the pro sidebar's "Liste Générale" entry links here with
+  // a #general hash. Open the matching tab on mount and on later hash changes
+  // (clicking the sidebar item again while already on this page).
+  useEffect(() => {
+    const applyHash = () => {
+      const h = window.location.hash.replace("#", "");
+      if (h === "general" || h === "awaiting" || h === "proposed") {
+        setActiveTab(h);
+      }
+    };
+    applyHash();
+    window.addEventListener("hashchange", applyHash);
+    return () => window.removeEventListener("hashchange", applyHash);
+  }, []);
+
   // Background auto-refresh: keep the lists live so a dossier the admin just
   // pushed to the general pool (§3.2 "instantanément visible") — or one another
   // pro just claimed — appears/disappears without a manual reload. Updates the

--- a/src/components/layout/ProfessionalSidebar.tsx
+++ b/src/components/layout/ProfessionalSidebar.tsx
@@ -18,6 +18,7 @@ import {
   ChevronRight,
   Wallet,
   Star,
+  Layers,
   MessageSquare,
 } from "lucide-react";
 import { useSidebar } from "@/components/ui/sidebar";
@@ -114,6 +115,14 @@ export function ProfessionalSidebar() {
           url: "/professional/dashboard/proposals",
           icon: Star,
           badge: pendingProposalsCount,
+        },
+        {
+          // Direct entry point to the always-open general pool ("Liste
+          // Générale") — deep-links to the General tab of the Propositions page
+          // so every pro can browse and self-claim pooled clients (§3.2).
+          title: t("generalPool"),
+          url: "/professional/dashboard/proposals#general",
+          icon: Layers,
         },
         {
           title: t("myClients"),


### PR DESCRIPTION
## Context
Spec: standardize the request lifecycle so the general-pool list has the same feature set as **Demandes de service**.

## Finding: already implemented
Most of the spec already exists in the code:
- **Pool Général** (`/admin/dashboard/general-pool`) and **Demandes de service** (`/admin/dashboard/service-requests`) both render the **same** `RequestsQueueTable` component. Every row exposes the same actions — schedule, mark/unmark **Consultation ponctuelle rapide**, delete, and the assign/reassign dropdown (**Jumelage automatique** / **Liste générale** / a specific pro). No action is hidden by `routingStatus`, so the pool already mirrors Demandes de service exactly.
- **Lifecycle**: Tentative 1 (strict auto-match) → on refusal/timeout → Tentative 2 (relaxed) → on second refusal/timeout → returns to **Demandes de service** as `awaiting_admin`, where the admin assigns to a specific pro or sends to the **Liste Générale**. Proposal timeouts are **24h regular / 12h urgent** — unchanged (returned dossiers keep their original urgency, per decision).
- **Patients** stays the client CRM (distinct from the appointment-level pool), per decision.

## The one gap closed
The routing-status **filter chips** were enabled on Demandes de service but not on the pool. Enabled them on the pool too for exact UI parity. They only render for statuses actually present (general / refused), so no empty chips appear.

## Verification
`tsc` + `eslint` clean. Single-line, isolated change.