### PR TITLE
docs: AI operating model (AGENTS.md, CLAUDE.md, docs/, skills)

### DIFF
--- a/.claude/skills/create-spec/SKILL.md
+++ b/.claude/skills/create-spec/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: create-spec
+description: Turn a feature request or change idea into a written spec under specs/NNN-slug/spec.md before any planning or coding. Use when the user says "write a spec", "spec this out", "let's scope this feature", or describes something new to build.
+argument-hint: <short feature description>
+---
+
+# Create a spec
+
+Turn a feature request into a reviewable spec. Do **not** plan implementation steps or write code here — that's `/plan-feature` and `/implement-feature`.
+
+## Steps
+
+1. **Ground first.** Read [AGENTS.md](../../../AGENTS.md), the relevant parts of [docs/architecture/overview.md](../../../docs/architecture/overview.md), and the [debt-map](../../../docs/quality/debt-map.md). Skim neighbouring code so the spec reflects how this project actually works.
+2. **Locate the specs folder.** If `specs/` does not exist at the repo root, create it. Find the highest existing `NNN` and use the next zero-padded number (start at `001`). Create `specs/NNN-slug/spec.md` with a short kebab-case slug.
+3. **Write the spec** with these sections:
+   - **Problem** — what user/operator need this serves (tie to a [CUJ](../../../docs/product/critical-user-journeys.md) or the [PRD](../../../docs/product/prd.md) goal where relevant; the primary goal is *faster matching*).
+   - **Acceptance criteria** — testable bullets ("given/when/then" where useful). Include the bilingual requirement if any user-facing copy changes (EN + FR lockstep).
+   - **Out of scope** — what this explicitly does not do (respect the product non-goals: not a crisis line, not an EHR, no insurance billing, B2B lead-capture only).
+   - **Affected files / legacy zones** — list the likely files/modules. **Cross-check the [debt-map](../../../docs/quality/debt-map.md)**: if the work touches a god-file, money/state-machine code, the matcher (`cascadeAttempts` vs `refusedBy`), `parseAppointmentDate`, encryption ordering, or `/api/files/[id]`, call it out as a risk.
+   - **Test plan** — which `*.spec.ts` to add/extend (pure logic in `src/lib`, route guards under `src/app/api`) and which CUJ to verify manually. Note that there is no UI test harness, so UI changes need manual verification.
+4. **Keep it additive and honest** — note any assumptions and any open questions for the user. Don't invent product intent; ask if unsure.
+5. **Hand off.** Point the user to `/plan-feature` with the spec path.

--- a/.claude/skills/encode-lesson/SKILL.md
+++ b/.claude/skills/encode-lesson/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: encode-lesson
+description: Turn a correction, recurring mistake, or newly-learned gotcha into permanent machinery so it can't recur. Use when the user corrects you, when a bug reveals a trap, or says "make sure this doesn't happen again", "encode this", "remember this for next time".
+argument-hint: <the mistake or lesson>
+---
+
+# Encode a lesson
+
+When something went wrong (or a correction was given), make the fix permanent in the **same PR**. Prefer a blocking mechanism over prose.
+
+## Choose the strongest mechanism that fits
+
+1. **A test** (best for logic/regressions) — add a `*.spec.ts` that fails on the mistake and passes on the fix. Pure logic in `src/lib`, route guards under `src/app/api`. This is the default for anything money/auth/routing.
+2. **A check / lint rule** — if the mistake is mechanical and detectable, add an ESLint rule (the config is in `eslint.config.mjs`) or a small check script. **Propose any gate change separately and explicitly** — never weaken an existing gate to "encode" something.
+3. **A documented invariant** — if no automated guard is practical, add a dated line to the right doc:
+   - A landmine / fragile area → append to [docs/quality/debt-map.md](../../../docs/quality/debt-map.md) (it is append-only) with a `[P#]` severity and the date.
+   - A convention for new code → [docs/conventions/code-style.md](../../../docs/conventions/code-style.md) §(b).
+   - A "handle with care" zone → [AGENTS.md](../../../AGENTS.md) §7 and/or the debt-map.
+   - A flow that must be verified → register/extend a [CUJ](../../../docs/product/critical-user-journeys.md).
+
+## Rules
+
+- Always do the **minimum durable thing**: at least a dated doc line; ideally a test or check.
+- Keep one home per fact — link rather than duplicate.
+- Note in the PR/commit what was encoded and why (`docs:` or `test:` commit), so the lesson is traceable.
+- If the lesson is a personal/process preference rather than a repo fact, tell the user it belongs in their Claude memory, not the repo docs.

--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: implement-feature
+description: Execute an agreed plan in small, verified, conventional commits. Use when the user says "implement this", "build it", "start coding", or approves a plan to carry out.
+argument-hint: <plan or spec path>
+---
+
+# Implement a feature
+
+Carry out a plan with discipline. Keep the build green at every step.
+
+## Steps
+
+1. **Re-ground.** Read [AGENTS.md](../../../AGENTS.md) and the plan/spec. Confirm the branch: if you're on `main`, create a feature branch first (`feat/...` or `fix/...`).
+2. **Work in small steps**, one logical change at a time:
+   - New code follows [docs/conventions/code-style.md](../../../docs/conventions/code-style.md) **§(b)**: strict TS, **no new `any`**, `@ts-expect-error <reason>` not `@ts-ignore`; validate at trust boundaries; new business logic goes in a `src/lib/*` module with a `*.spec.ts`, called from a thin route/handler; never trust the client for role/ownership.
+   - **Bilingual lockstep**: every user-facing string in **both** `messages/en.json` and `messages/fr.json`. Thread `lang` through email builders.
+   - Match the neighbouring file's patterns when editing inside an existing (legacy) module; don't rewrite god-files — edit surgically.
+   - Respect the invariants: write appointment dates via `parseAppointmentDate`; never derive `cascadeAttempts` from `refusedBy`; issue receipts only when `payment.status === "paid"`.
+3. **Test as you go.** For a bug fix, write the **failing regression test first**. For new logic, add its spec. Run `pnpm test` (and `pnpm exec tsc --noEmit` for a fast typecheck) after each step.
+4. **Commit** each green step with a Conventional Commit message (`feat:`, `fix:`, `docs:`, `chore:` …), matching the existing history.
+5. **Never weaken a gate** to make something pass (no `ignoreBuildErrors`, no deleting a test, no loosening `strict`). If a gate is genuinely wrong, propose the change separately.
+6. **Stop after two failed attempts** at the same fix — don't push a hack through. Ask one concrete question.
+7. When done, run `/verify`. If a mistake could recur, run `/encode-lesson` in the same PR.

--- a/.claude/skills/plan-feature/SKILL.md
+++ b/.claude/skills/plan-feature/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: plan-feature
+description: Produce a concrete, step-by-step implementation plan from a spec (or a described feature) before writing code. Use when the user says "plan this", "how would you build this", "make a plan", or hands you a spec to implement.
+argument-hint: <spec path or feature description>
+---
+
+# Plan a feature
+
+Turn a spec into an ordered, file-level plan. No code yet.
+
+## Steps
+
+1. **Ground.** Read [AGENTS.md](../../../AGENTS.md) (the loop, rules for new code, legacy zones) and the spec if one exists (`specs/NNN-slug/spec.md`). Read [docs/architecture/overview.md](../../../docs/architecture/overview.md) for where things live and [docs/conventions/code-style.md](../../../docs/conventions/code-style.md) §(b) for how new code must look.
+2. **Inventory existing code first — reuse, never recreate.** Search `src/lib`, `src/components`, `src/app/api`, and `src/models` for existing helpers, patterns, models, and i18n keys you can extend. Prefer extending an existing `lib/` service or component over inventing a new one. Note what you'll reuse.
+3. **Check legacy-zone contact.** Cross-reference the [debt-map](../../../docs/quality/debt-map.md). If the plan touches: a god-file (`notifications.ts`, `email-template-registry.ts`, `appointment/page.tsx`, `MedicalProfile.tsx`), money/state-machine code (webhook, payout, `complete-session`, the matcher), `parseAppointmentDate`, the `User` encryption-hook ordering, or `/api/files/[id]` — flag it explicitly and plan to add a test.
+4. **Write the plan** as ordered steps, each with: the **file paths** to touch, what changes, and the **verification** for that step (which `pnpm test` spec, or which [CUJ](../../../docs/product/critical-user-journeys.md) to exercise). Keep new business logic in a `src/lib/*` module called by a thin route. Put any user-facing copy in **both** `messages/en.json` and `messages/fr.json`.
+5. **Sequence to keep the build green** — small steps, each independently verifiable. Identify the riskiest step and do it behind a test.
+6. **Surface decisions** that need the user (anything that changes product behaviour, scope, or a non-goal). Then hand off to `/implement-feature`.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: review
+description: Review the current diff against the project's rules, conventions, and debt map before merging. Use when the user says "review this", "review my changes", "look over the diff", or "is this ready to merge".
+argument-hint: (optional) base ref, e.g. main
+---
+
+# Review the current diff
+
+Review what changed against the harness rules. Output findings ranked **P1 / P2 / P3**, with file:line and a concrete fix.
+
+## Steps
+
+1. **Get the diff.** `git status` and `git diff` (vs `main` or the given base). Read each changed file's surrounding context, not just the hunks.
+2. **Check against the rules** ([AGENTS.md](../../../AGENTS.md) §6 + [code-style §(b)](../../../docs/conventions/code-style.md)):
+   - **Layer/boundary respect** — new business logic in `src/lib/*` (with a spec) and called from a thin route, not piled into a god-file or a route handler. Components stay presentational.
+   - **Type honesty** — **no new `any`**, no new `@ts-ignore` (only `@ts-expect-error <reason>`). 
+   - **Tests present** — new logic has a `*.spec.ts`; a bug fix has a regression test. Money/auth/routing changes are not OK without a test.
+   - **No weakened gates** — no `ignoreBuildErrors`/`ignoreDuringBuilds`, no relaxed `strict`, no deleted/skipped tests, no loosened lint.
+   - **Bilingual lockstep** — any user-facing copy touched in **both** `messages/en.json` and `messages/fr.json`; email changes thread `lang`.
+   - **Validation at trust boundaries** — server-side role/ownership checks (don't rely on UI gating); input validated.
+3. **Check against the [debt-map](../../../docs/quality/debt-map.md) and legacy zones.** Flag any casual edit to: the matcher (`cascadeAttempts` vs `refusedBy`), the Stripe webhook / payout / `complete-session` money paths, `parseAppointmentDate`, the `User` encryption-hook order, `/api/files/[id]` auth, or any god-file rewrite. Flag any **new** duplicate of an already-duplicated system (CMS, email config, file storage).
+4. **Check CUJ impact.** If the diff touches a [critical user journey](../../../docs/product/critical-user-journeys.md), confirm it was verified (tests run and/or app exercised). The untested CUJs (webhook, guest payment, booking/signup routes) need extra scrutiny.
+5. **Output** findings as `P1/P2/P3 — file:line — problem — suggested fix`. P1 = correctness/security/money/data-loss; P2 = rule violation or real risk; P3 = style/cleanup. If clean, say so plainly. Do **not** edit code in this skill — report only.

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: update-docs
+description: After a merged or completed change, update any stale docs so they keep matching the code. Use when the user says "update the docs", "keep the docs in sync", or after finishing a feature that changed behaviour, structure, or product scope.
+argument-hint: (optional) what changed
+---
+
+# Update the docs
+
+Keep the operating docs true to the code. One fact, one home — update where it lives, don't duplicate.
+
+## Steps
+
+1. **Identify what changed** (read the diff / the completed work) and which docs it affects.
+2. **Update the right doc(s):**
+   - New/changed flow, structure, or integration → [docs/architecture/overview.md](../../../docs/architecture/overview.md). A material architectural decision → add a new ADR in [docs/architecture/decisions/](../../../docs/architecture/decisions/) (next `NNNN`).
+   - New convention for new code → [docs/conventions/code-style.md](../../../docs/conventions/code-style.md) §(b).
+   - New landmine / fixed-or-discovered debt → [docs/quality/debt-map.md](../../../docs/quality/debt-map.md) (append-only, dated, `[P#]`). If a debt item was actually resolved, note it as resolved with the date — don't silently delete the history.
+   - New/changed user-visible capability → [docs/product/overview.md](../../../docs/product/overview.md), and register/extend a [CUJ](../../../docs/product/critical-user-journeys.md). Requirement change → [/write-prd](../write-prd/SKILL.md) (append to the PRD decision log).
+3. **Check internal links resolve.** Every relative link in the touched docs must point at a real file, and [docs/index.md](../../../docs/index.md) must list every file under `docs/`. If you added a doc, add its index line.
+4. **Reconcile, don't accrete.** If a doc claim is now wrong, fix it in place; if a fact moved, move the single home and re-point links. Flag (don't fix) anything outside the scope of this change.
+5. Commit with a `docs:` Conventional Commit.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: verify
+description: Run the project's real green sequence and prove a change works before claiming done. Use when the user says "verify", "is it green", "did it work", "check the build", or before finishing any task.
+argument-hint: (optional) what changed / which CUJ to exercise
+---
+
+# Verify
+
+Produce an **evidence summary**, never a bare "done". The Vercel build is the only deploy gate and it does **not** run tests — so run them yourself.
+
+## The green sequence (real commands)
+
+Run from the repo root and capture the output. **"Green" = `pnpm test` and `pnpm build` both pass.**
+
+1. `pnpm test` — Vitest (`*.spec.ts`, node env). Focused run: `pnpm test <path-or-name>`. Must pass.
+2. `pnpm build` — `next build`: the deploy gate (what Vercel runs). Enforces the **strict TypeScript typecheck** + bundling. Treat a failing build as not-done. (`pnpm exec tsc --noEmit` is a faster typecheck-only check — the compiler directly, not a package.json script.)
+3. `pnpm lint` — ESLint. **Advisory, not a gate**: the tree has ~84 pre-existing errors and `next build` (Next 16) does not run ESLint. Don't aim for zero — just confirm you added **no new** errors in the files you touched (compare against the baseline).
+
+(`pnpm seed` is broken — don't use it. Never point the `tsx` ops scripts at the prod DB.)
+
+## For UI / behaviour changes
+
+There are **no automated UI tests**, so manual verification is required:
+
+1. `pnpm dev` and open the app. Sign in with the relevant role (admin / professional / client) — use test accounts (e.g. `@test.local`), never real client data.
+2. Exercise the **[critical user journey](../../../docs/product/critical-user-journeys.md)** the change touches, end to end. Confirm both **EN and FR** if copy changed (toggle the locale).
+3. For money/state-machine changes (CUJ-5/6/7), confirm the resulting DB state and that a receipt is issued **only** when `payment.status === "paid"`.
+4. Clean up any test data you created.
+
+## Output
+
+A short evidence summary: each command run + its result (pasted, not paraphrased), which CUJ was exercised and what you observed, and anything still unverified. If a step failed, say so with the output — do not claim done.

--- a/.claude/skills/write-prd/SKILL.md
+++ b/.claude/skills/write-prd/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: write-prd
+description: Re-derive or update the product requirements doc (docs/product/prd.md) when requirements, goals, or scope change. Use when the user says "update the PRD", "write a PRD", "the requirements changed", or wants product intent captured.
+argument-hint: (optional) what changed about the requirements
+---
+
+# Write / update the PRD
+
+Maintain [docs/product/prd.md](../../../docs/product/prd.md) with the same discipline used to reverse-engineer it. The PRD is the product's source of intent; keep it honest.
+
+## Steps
+
+1. **Read the current PRD** and the [product overview](../../../docs/product/overview.md) + [CUJs](../../../docs/product/critical-user-journeys.md) so you build on what's there.
+2. **Observed vs inferred discipline.** Every claim is either **observed** (cite the file/route/model/copy it comes from) or **`[inferred]`**. What the code can show — routes, models, copy, integrations — must be grounded in the code. Don't restate marketing claims as facts.
+3. **Interview only for gaps.** Business goals, non-goals, success metrics, targets/SLAs, and scope are **not** in the code — ask the user (focused questions, AskUserQuestion-style). Anything still unknown becomes an **Open Question**, never an assumption. (Current baseline: primary goal = *faster matching*; non-goals = not-a-crisis-line / not-an-EHR / no-insurance-billing / B2B-lead-capture-only; metrics = time-to-match, acceptance rate, booking→paid, pro utilization; scope = Quebec now, international later.)
+4. **Update the sections**: problem & opportunity · goals & non-goals · users & jobs · current scope (ranked by centrality) · constraints · success metrics · open questions · decision log. Re-rank scope by what the code/usage shows is central.
+5. **Append to the decision log** — a dated entry describing what changed and who confirmed it. Never rewrite history; add to it.
+6. Keep it consistent with the [PRD](../../../docs/product/prd.md)'s sibling docs; if scope changed, also run [/update-docs](../update-docs/SKILL.md) for the overview and CUJs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md — Je chemine operating manual
+
+The entry point for every AI (and human) session in this repo. Read it once, in full, before you touch anything.
+
+## 1. What this repository is
+
+**Je chemine** (`jechemine`, prod **www.jechemine.ca**) is a bilingual (FR-first / EN) Quebec mental-health **"Plateforme de santé mentale™ / Integrated Health Platform™"**. It connects clients/members with vetted professionals through an intelligent **jumelage** (matching) engine, then carries the relationship through booking, payment (Stripe + Interac), internal messaging, fiscal receipts, and an editorial CMS. Stack: **Next.js 16.0.10** (App Router, React 19.2 + React Compiler), **TypeScript 5.9 (strict)**, **MongoDB/Mongoose 8** (+ `@auth/mongodb-adapter`), **NextAuth v4** (JWT), **Stripe 19** (+ Connect), **Nodemailer SMTP** + **Twilio**, **next-intl**, **Tailwind 4 + shadcn/ui (new-york) + Radix + CVA**, **Tiptap**, **Vitest 1.6**, package manager **pnpm**. It is **in production and live** — this is an evolution, not a migration. We are adopting an AI operating model on top of the code **as it is**; we document legacy patterns, we do not silently "fix" them (see [ADR-0001](docs/architecture/decisions/0001-adopt-ai-operating-model.md)).
+
+## 2. The loop — every task follows this
+
+1. **Ground** — read the docs in §4 relevant to the task, and read the *neighbouring* code, before writing anything. Reuse existing patterns; never recreate what exists.
+2. **Plan** — for anything beyond a trivial fix, state a short plan first (see `/plan-feature`). Flag any contact with a Legacy Zone (§7) or [debt-map](docs/quality/debt-map.md) landmine.
+3. **Implement** — small steps, keep the build green. New code follows [code-style §(b)](docs/conventions/code-style.md); existing code is left alone unless the task is about it.
+4. **Verify** — run the real check commands (§3) and *prove* the change works. For UI, run the app and confirm the touched [CUJ](docs/product/critical-user-journeys.md). Never claim "done" without evidence (see `/verify`).
+5. **Encode** — if a mistake could recur, write the fix into a doc, test, or rule in the **same PR** (see `/encode-lesson`). Prefer a blocking mechanism over prose.
+
+## 3. Commands (the project's real commands — pnpm)
+
+| Command | Purpose |
+| --- | --- |
+| `pnpm dev` | Run the dev server (Next 16 / Turbopack). |
+| `pnpm build` | `next build` — **the deploy gate** (Vercel runs this): enforces the **strict TypeScript typecheck** + bundling. Note: Next 16 does **not** run ESLint during build, so lint errors do **not** block it. |
+| `pnpm test` | Vitest — **34 `.spec.ts` files, node env**: pure logic + a slice of route guards. **No UI/component tests exist.** |
+| `pnpm lint` | ESLint (`eslint-config-next` core-web-vitals + typescript). **Advisory only** — see below. |
+| `pnpm format` | Prettier (`--write .`). |
+| `pnpm prune` | knip — dead code / unused deps. |
+| `pnpm create-admin` / `pnpm seed-motifs` / `pnpm reset-motifs` / `pnpm seed-routing-test` | `tsx` ops scripts. ⚠ destructive — never point at the prod DB. |
+
+**"Green" = `pnpm test` passes AND `pnpm build` passes** (build = the strict typecheck). `pnpm lint` is **advisory**: the tree carries a large pre-existing ESLint backlog (~84 errors) and `next build` does not enforce it — so don't aim for a clean `pnpm lint`, just **don't add new lint errors** in files you touch. (`pnpm exec tsc --noEmit` is a faster standalone typecheck — the installed compiler directly, *not* a package.json script. `pnpm seed` is **broken** — points at a non-existent file; see debt-map.) There is **no CI gate at all** — only the Vercel `next build` runs, and it runs neither vitest nor ESLint. So run `pnpm test` yourself: a logically-broken-but-compiling change can ship.
+
+## 4. Docs map — which doc for which task
+
+| You are… | Read |
+| --- | --- |
+| Doing anything | this file + [docs/index.md](docs/index.md) |
+| Understanding the system / where code lives | [docs/architecture/overview.md](docs/architecture/overview.md) |
+| Writing new code (style, boundaries, validation) | [docs/conventions/code-style.md](docs/conventions/code-style.md) |
+| Touching fragile areas / before a big change | [docs/quality/debt-map.md](docs/quality/debt-map.md) |
+| Working on a user-facing flow | [docs/product/critical-user-journeys.md](docs/product/critical-user-journeys.md) |
+| Needing product intent / scope / why | [docs/product/prd.md](docs/product/prd.md) + [docs/product/overview.md](docs/product/overview.md) |
+| Recording an architectural decision | [docs/architecture/decisions/](docs/architecture/decisions/) |
+
+## 5. Architecture as it is (honest)
+
+- **Routes/pages** live in `src/app/**` (App Router): route groups `(public)`, `(auth)`, `(verify)`, `(privilaged)`[admin/client/professional], plus the standalone `/appointment` (booking funnel) and `/pay` (guest payment) flows. ~82 pages.
+- **API** is ~154 `route.ts` handlers under `src/app/api/**`. There is **no shared auth helper**: every route inlines `getServerSession(authOptions)` + a role/ownership check (~345 call sites). `src/middleware.ts` only injects `x-pathname` for `/professional/*` — it does **not** enforce auth.
+- **Business logic** lives mostly in `src/lib/**` services (matcher `appointment-routing.ts`, `notifications.ts`, `payment-settlement.ts`, `session-post-closure.ts`, `account-merge.ts`, …) — but a meaningful amount is **also inline in big route handlers and pages** (booking funnel, webhook, payout, no-show billing).
+- **Data**: 25 Mongoose models in `src/models`. `User` and `Appointment` are central; **`Appointment` doubles as the service-request record** (it can have no pro/date while `routingStatus` is pending). Field-level AES-256-GCM encryption on contact fields. See overview + debt-map for the `routingStatus`/`cascadeAttempts` state machine.
+- **Frontend**: heavily client components (`"use client"`, ~192 files), plain React hooks (no Redux/Zustand/SWR), shadcn/Tailwind, all copy via next-intl (FR+EN **lockstep**).
+
+## 6. Rules for new code (applied from now on — old code is grandfathered)
+
+- New code follows [docs/conventions/code-style.md](docs/conventions/code-style.md) §(b). Inventory existing code first and **extend existing patterns** rather than inventing new ones.
+- **Bilingual lockstep**: any user-facing copy change updates **both** `messages/en.json` **and** `messages/fr.json`. Thread `lang` through email builders.
+- TypeScript: **no new `any`**, **no new `@ts-ignore`** (use `@ts-expect-error` with a reason). Old code has ~91 `any`s — don't add to them.
+- New logic gets a test; a bug fix gets a **regression test first**. Tests are `*.spec.ts` (vitest, node env) — pure functions in `src/lib`, route guards under `src/app/api`.
+- **Conventional Commits** (`feat:`, `fix:`, `docs:`, `chore:`…), matching the existing history.
+- **Never weaken a gate** (lint rule, test, tsconfig strict, `ignoreBuildErrors`) to make work pass. Propose gate changes separately and explicitly.
+- Validate at trust boundaries (user input, network, storage). Money, auth, and routing changes need extra care and a test.
+- **Boy-scout cleanup is opt-in** — only refactor adjacent legacy code when explicitly asked; otherwise log it in the debt-map.
+
+## 7. Legacy zones — handle with care
+
+- **Money & state machines**: `src/app/api/payments/webhook/route.ts` (untested), `src/app/api/stripe-connect/payout/route.ts` (atomic claim / idempotency / Connect verification), `src/app/api/appointments/[id]/complete-session/route.ts` (charges money + closes billing). Regressions move/lose money. Always add a test.
+- **The matching cascade**: `Appointment.cascadeAttempts` is **deliberately distinct** from `refusedBy` — do not derive one from the other (release/reassign also write `refusedBy`). See debt-map.
+- **God-files** (edit surgically, don't rewrite): `lib/notifications.ts` (~6.7k lines), `lib/email-template-registry.ts` (~3k), `app/appointment/page.tsx` (~3.1k), `signup/member`, `MedicalProfile.tsx`.
+- **Dates**: always write appointment dates through `parseAppointmentDate` (UTC-noon anchor) — never `new Date("YYYY-MM-DD")`.
+- **Encryption ordering**: the `User` lookup-hash pre-save hook must run **before** the contact-encryption plugin (phone must still be plaintext). Don't reorder.
+- **`/api/files/[id]`**: coarse auth (any signed-in user can read any non-`content-image` file by id) + a BSON-Binary empty-body trap — keep the normalize branch.
+- See the full list, including the **`admin@admin.com`/`admin123` production super-admin**, in [docs/quality/debt-map.md](docs/quality/debt-map.md).
+
+## 8. When unsure
+
+Stop after **two** failed attempts at the same fix and ask one concrete question instead of pushing a hack through. If a doc contradicts the code, the doc may be stale — flag it and propose the doc fix in the **same PR**. When a change is hard to reverse or touches money/auth/PII, confirm before proceeding.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/architecture/decisions/0001-adopt-ai-operating-model.md
+++ b/docs/architecture/decisions/0001-adopt-ai-operating-model.md
@@ -1,0 +1,27 @@
+# ADR-0001 — Adopt the AI operating model without migrating legacy code
+
+- **Status**: Accepted
+- **Date**: 2026-06-20
+- **Deciders**: Product owner + maintainers (harness installed by an AI session)
+
+## Context
+
+Je chemine is a live, in-production Quebec mental-health platform (Next.js 16 / MongoDB / NextAuth / Stripe). It predates our skeleton standards: it carries legacy patterns (the root `README.md` describes a Supabase/Zustand/RHF+Zod build that was never shipped; auth is copy-pasted inline across ~141 files; several modules are 1,000–6,700-line god-files; there is no CI test gate). The code works and serves real users. Rewriting it to match a "target" architecture would be high-risk and is not the goal.
+
+We want every future AI (and human) session to operate with discipline — ground in docs, plan, implement in small steps, verify with evidence, and encode lessons — **without** destabilizing the running system.
+
+## Decision
+
+Adopt the AI operating model **additively**, on top of the code as it is:
+
+1. Install operating docs ([AGENTS.md](../../../AGENTS.md), [architecture](../overview.md), [conventions](../../conventions/code-style.md), [debt-map](../../quality/debt-map.md)), a reverse-engineered product layer ([PRD](../../product/prd.md), [overview](../../product/overview.md), [CUJs](../../product/critical-user-journeys.md)), and workflow-enforcing skills under `.claude/skills/`.
+2. **New code** follows the target conventions in [code-style §(b)](../../conventions/code-style.md): strict TypeScript (no new `any`), validation at trust boundaries, tests for new logic, regression tests for bug fixes, Conventional Commits, bilingual lockstep.
+3. **Legacy code** is documented, not rewritten. Differences from the target are recorded as legacy patterns in the architecture overview and debt-map, never silently "corrected". Boy-scout cleanup is opt-in (explicit ask only).
+4. **Gates are never weakened** to make work pass. Future architectural choices are recorded as new ADRs in this folder.
+
+## Consequences
+
+- New code converges on the target conventions; the codebase improves at the edges without a risky big-bang migration.
+- The debt-map becomes the single, append-only home for known landmines; sessions add findings there instead of fixing-by-the-way.
+- There is a small, accepted inconsistency cost: new and legacy patterns coexist (e.g. RSC-less dashboards, inline auth) until a task deliberately addresses a given area.
+- Every materially new decision (a new data store, a real CI gate, a refactor of a god-file, a state-machine change) gets its own ADR here so the reasoning is preserved.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,88 @@
+# Architecture overview — the system as it is
+
+This describes **Je chemine** as it actually runs today, not as it was originally planned. (The root `README.md` is a stale April planning artifact that describes a Supabase / Zustand / React-Hook-Form+Zod build that was **never** the shipped stack — see [Known deviations](#known-deviations).)
+
+## Rendering & data-flow model
+
+- **Next.js 16 App Router**, React 19.2 with the **React Compiler** enabled (`next.config.ts: reactCompiler: true`). TypeScript strict.
+- The UI is **heavily client-side**: ~192 files carry `"use client"`. Server components are essentially the route-group `layout.tsx` files, which call `getServerSession`/`auth()` to gate by role. Dashboards self-fetch their data in `useEffect` (raw `fetch()` or a thin `apiClient` singleton) — there is **no RSC data-loading layer, no SWR/React Query, and no global store**. "Real-time" is 30–60s polling.
+- **Locale** is cookie-driven (`NEXT_LOCALE`), **not** a URL segment. `src/i18n/request.ts` defaults to **French** unless the cookie is exactly `en` (French-first by design). Copy lives in `messages/en.json` + `messages/fr.json` (lockstep). There is no `sitemap.ts`/`robots.ts`/`hreflang`.
+- **Auth**: NextAuth v4 Credentials (bcrypt) + `@auth/mongodb-adapter`, **JWT sessions, 30-min maxAge**. Role/status/license are copied onto the token at login — so admin changes to a logged-in user are invisible until re-login (the pro dashboard works around this by re-fetching `/api/users/me`).
+- **No edge auth**: `src/middleware.ts` only injects an `x-pathname` header for `/professional/*`. All access control lives inside route handlers and server layouts.
+- **Persistence**: MongoDB via a cached Mongoose singleton (`src/lib/mongodb.ts`, retrying transient errors) + a separate `clientPromise` for the NextAuth adapter. **No multi-document transactions** anywhere — consistency relies on single-document atomic `findOneAndUpdate` "claims".
+
+## Directory layout (role of each top-level folder)
+
+```
+src/
+  app/
+    (public)/        Marketing + CMS pages (home, services, approaches, explore, medias, nouveautes, legal, emergency, school-manager, contact)
+    (auth)/          login, signup (member|professional), forgot/reset-password
+    (verify)/        verify-account (email link → inline SMS)
+    (privilaged)/    admin/, client/, professional/ portals (note the spelling — it's the real folder name)
+    appointment/     The ~3,100-line multi-step booking funnel (self/loved-one/patient · guest/member · emergency/changeProfessional)
+    pay/             Token-based guest payment + payment-method setup (Stripe Elements)
+    api/             ~154 route.ts handlers (see below)
+    actions/         server actions (locale.ts)
+    layout.tsx · loading.tsx · not-found.tsx · error.tsx
+  components/        ~141 .tsx, by domain: admin, appointments, auth, billing, dashboard, inbox, layout, legal, media, payments, sections, ui (shadcn)
+  lib/              ~71 business-logic/service modules (the "brain") — see below
+  models/           25 Mongoose models
+  hooks/            use-mobile, useInactivityLogout, useMotifs, useMotifSearch
+  config/           clinical-availability-grid, motifSearch, colors
+  data/             static FR-first taxonomies (problematics, diagnostics, approaches, motifs, professionalTitles)
+  i18n/             next-intl request config
+  test/             vitest setup (mocks next-intl, stubs MONGODB_URI + FIELD_ENCRYPTION_KEY)
+  middleware.ts · theme.ts
+messages/           en.json + fr.json (the i18n catalogs)
+scripts/            one-shot tsx ops scripts (backfill, add-stripe-webhook-events)
+vercel.json         5 daily crons (+ in-app "lazy cron" for the matching cascade — lib/lazy-cron.ts)
+```
+
+### Where business logic lives
+
+The core lives in `src/lib/**` and is consumed by route handlers:
+
+- **Matching / jumelage** — `lib/appointment-routing.ts`: `calculateRelevancyScore` (pure, scored), `selectCascadeCandidate` (pure, 3-level cascade), `routeAppointmentToProfessionals` (commits routing atomically). Hard filters: **age** and **stated gender preference** only; everything else is soft scoring so the pool never empties.
+- **Appointment routing state** — encoded on the `Appointment` doc (see [state machine](#the-appointment--service-request-state-machine)). Proposal timeouts in `lib/proposal-timeout.ts`.
+- **Payments** — `lib/pricing.ts`, `lib/stripe.ts`, `lib/payment-settlement.ts`, `lib/session-post-closure.ts` (`issueFiscalReceipt`), `lib/session-closure.ts` (no-show billing), `lib/stripe-off-session-charge.ts`, `lib/payment-guarantee.ts`.
+- **Notifications** — `lib/notifications.ts` (~6.7k lines): one `buildEmailHtml` builder behind ~46 `send*` functions, backed by the admin-editable `EmailTemplate` registry (`lib/email-template-registry.ts`, 45 keys, mustache `{{#}}/{{^}}` conditionals) with bilingual fallbacks. `getAdminAlertRecipients` centralizes alert routing.
+- **Accounts** — `lib/service-request.ts` (intake → single pending Appointment), `lib/account-dedup.ts` + `lib/account-merge.ts` (phone/name dedup, client-only merge), `lib/messaging-permissions.ts`.
+- **Cross-cutting** — `lib/mongoose-contact-encryption.ts` (AES-256-GCM), `lib/appointment-date.ts` (`parseAppointmentDate` UTC-noon), `lib/admin-rbac.ts` (13-permission RBAC + PII masking), `lib/platform-contact.ts`, `lib/rate-limit.ts` (in-memory, per-instance).
+
+⚠ A meaningful amount of orchestration is **also inline in route handlers and pages** (the booking funnel, the Stripe webhook, the payout route, no-show billing math) rather than fully extracted to `lib/`.
+
+## The Appointment / service-request state machine
+
+A service request **is** an `Appointment` document (it may have no `professionalId`/`date`/`time` while routing). Two fields drive routing:
+
+- **`routingStatus`**: `pending` → `proposed` (targeted offer, stamps `proposedAt`) → `accepted` (a pro takes it, stamps `matchedAt`; `status` stays `pending` until scheduled) **or** `refused`. When the targeted cascade is exhausted it returns to **`awaiting_admin`** (the admin "Demande de service" queue — **not** the pro pull). **`general`** = the always-open pool any active pro can self-claim.
+- **`cascadeAttempts`** (the 3-level cascade counter): `0` → Tentative 1 **strict** (score ≥ 100 + availability), `1` → Tentative 2 **relaxed** (score ≥ 20), `≥ 2` → `awaiting_admin`. It is **deliberately separate** from **`refusedBy`** (the never-re-propose exclusion set, which release/reassign also write). Incremented only by a genuine refusal or a proposal timeout; reset to 0 when an admin re-runs auto-matching.
+
+**Accept = match only.** A separate `schedule-first` sets the real date (via `parseAppointmentDate`), flips `status` to `scheduled`, and sends the single payment-invitation email. The client is **not** emailed on release/reassignment — they stay silent until a pro accepts.
+
+## External services & integrations
+
+- **MongoDB Atlas** (data + binary file storage as BSON `Buffer` in `StoredFile`, because Vercel's FS is read-only).
+- **Stripe 19** (`apiVersion 2025-10-29.clover`) — **separate charges & transfers** model: PaymentIntents carry no `application_fee`/`transfer_data`; the platform collects the full charge then pays pros later via admin-triggered `transfers.create` to Express Connect accounts (the platform holds the float). The **webhook** (`api/payments/webhook`, raw body, signature-verified, idempotent via `StripeWebhookEvent`) handles 7 event types (payment success/fail/cancel, full/partial refund with receipt void/restore, dispute, `setup_intent.succeeded`).
+- **SMTP email** via Nodemailer (`lib/email-transport.ts`), **fail-soft** (skips silently if unconfigured). `MAIL_FROM` must equal `SMTP_USER` or be a verified Gmail alias.
+- **Twilio** SMS via raw REST (`lib/sms.ts`), best-effort; `SMS_DRY_RUN` for local.
+- **Crons**: 5 daily routes (`vercel.json`) guarded by a shared `Bearer CRON_SECRET`. The time-sensitive **matching cascade** (24h/12h proposal timeouts) no longer depends on a scheduler — an **in-app "lazy cron"** (`lib/lazy-cron.ts`, throttled via a `CronRun` DB heartbeat) advances it off the admin-queue / pro-proposals polls. An external pinger (e.g. cron-job.org) hitting the same `CRON_SECRET`-guarded endpoints is the optional 24/7 backstop. All runners are idempotent.
+
+## Entry points
+
+- **Web**: `src/app/layout.tsx` (root) → route groups. Public booking entry is `/appointment`; guest payment is `/pay?token=`.
+- **API**: each `src/app/api/**/route.ts` exporting `GET/POST/PATCH/PUT/DELETE`. Stripe → `api/payments/webhook`. Crons → `api/cron/*`.
+- **Background**: the 5 cron runners in `lib/*-reminders.ts` / `lib/proposal-timeout.ts`.
+
+## Known deviations from a "target" architecture
+
+These are recorded factually — they are **not** to be "fixed" except when a task is explicitly about them (see [ADR-0001](decisions/0001-adopt-ai-operating-model.md)).
+
+- **`README.md` is obsolete**: it specifies Supabase, Zustand, React-Hook-Form+Zod, Framer-only, and a mock-JSON build. The real stack is Next.js 16 + MongoDB/Mongoose + NextAuth + Stripe, plain React state, no form library. The README is still useful as the *original product scaffold* (phases, Sentiers branch).
+- **No shared auth/authz helper** — `getServerSession` + role/ownership checks are copy-pasted across ~141 files (~345 sites). A gate change must be made everywhere by hand.
+- **Business logic inline in routes/pages** rather than thin routes over `lib/` services (booking funnel, webhook, payout, dashboard payment-flags).
+- **God-files**: `lib/notifications.ts` (6.7k), `email-template-registry.ts` (3k), `app/appointment/page.tsx` (3.1k), `MedicalProfile.tsx` (2.2k), `signup/member` (2.1k).
+- **Two of several things** coexist: two CMS models (`Problematique` legacy vs `ContentEntry`), two email-config layers (`PlatformSettings.emailSettings.templates` legacy vs `EmailTemplate`), two file mechanisms (`StoredFile` bytes vs `ClientDocument` URLs), two shadcn primitive generations, two animation systems (CSS keyframes + framer-motion), `guardianId` vs `accountManagerId`.
+- **Orphaned design tokens**: `src/theme.ts` (indigo/purple) and `src/config/colors.ts` do **not** match the authoritative OKLCH variables in `globals.css`; `globals.css` references undefined `--font-*` variables (no `next/font` loaded).
+- **No CI quality gate** — the Vercel `next build` is the only pre-deploy gate and does not run vitest. See [debt-map](../quality/debt-map.md).

--- a/docs/conventions/code-style.md
+++ b/docs/conventions/code-style.md
@@ -1,0 +1,51 @@
+# Code style & conventions
+
+Two sections. **(a)** is what the codebase does *today* — match it when editing inside an existing legacy module. **(b)** is the target for *new* code. **Where (a) and (b) conflict, follow (b) in new files; match (a) only when editing inside an existing legacy module.**
+
+---
+
+## (a) Detected conventions (as they exist today)
+
+### Language & tooling
+- **TypeScript strict** (`tsconfig.json: strict: true`, `noEmit: true`). Path alias `@/* → src/*`.
+- **pnpm** is canonical (the `pnpm` block in `package.json` + freshest lockfile). Stale `bun.lock` and `package-lock.json` are committed but unused — ignore them (see [debt-map](../quality/debt-map.md)).
+- **ESLint flat config** = `eslint-config-next` core-web-vitals + typescript presets, **zero custom rules**. `@typescript-eslint/no-explicit-any` is therefore active (and locally suppressed ~23 times). ⚠ **Lint is advisory, not a gate**: `next build` (Next 16) does **not** run ESLint, and `pnpm lint` currently reports ~84 pre-existing errors — so a clean lint run is not achievable today (see [debt-map](../quality/debt-map.md)). Don't add new lint errors in files you touch.
+- Type honesty is mostly good: **0 `@ts-ignore` in production code** (2 `@ts-expect-error` in tests), but **~91 `any`** cluster in `admin/admins` routes + `lib/api-client.ts`.
+
+### Files & naming
+- Components are **PascalCase** `.tsx`, organized by **domain folder** under `src/components/` (`admin`, `appointments`, `billing`, `dashboard`, `inbox`, `payments`, `sections`, `ui`, …); some folders use a barrel `index.ts`.
+- API routes are App Router `route.ts` files exporting `GET/POST/PATCH/PUT/DELETE`. Dynamic segments `[id]`, `[kind]`, `[slug]`.
+- Lib modules are kebab-case (`appointment-routing.ts`, `payment-settlement.ts`). Tests are co-located **`*.spec.ts`** (never `.test.*`).
+- Mongoose models are PascalCase singular (`User.ts`, `Appointment.ts`), one model per file, registered with the hot-reload-safe idiom `mongoose.models.X || mongoose.model<IX>("X", schema)`.
+- Mixed default vs named exports for components (most `ui` primitives are named; some feature components default-export).
+
+### Styling
+- **Tailwind 4** (CSS-first config in `src/app/globals.css`, no `tailwind.config`) + **shadcn/ui "new-york"** + Radix primitives + **class-variance-authority (CVA)** for variants. Compose classes with the single **`cn()`** helper (`src/lib/utils.ts` = `twMerge(clsx(...))`).
+- Authoritative design tokens are **OKLCH CSS variables** in `globals.css` (`--primary` is a muted blue; headings use `font-serif font-light`). `src/theme.ts` and `src/config/colors.ts` are **not** the live palette — don't edit them expecting visual change.
+- Two shadcn generations coexist (older `forwardRef`+`displayName` vs newer functional `data-slot`); a hand-rolled CSS `@keyframes`/`animate-*` library + `ScrollReveal` coexist with framer-motion.
+
+### State, data, forms
+- **Plain React hooks** (`useState`/`useEffect`/`useRef`). No Redux/Zustand/Jotai, no SWR/React Query. Context only from `SessionProvider`, `NextIntlClientProvider`, and shadcn's own.
+- Data fetching is split between a thin `apiClient` singleton (`src/lib/api-client.ts`) and **raw `fetch()`** — no unified data layer or caching (except the hand-rolled `useMotifs` module cache).
+- **No form library and no client-side schema validation library** (no react-hook-form, no zod in components). Forms are controlled inputs with manual, ad-hoc validation. Feedback is via **inline state-driven banners** (track an explicit `messageType` — do **not** string-match localized text); a couple of components still use `window.alert`.
+- **i18n is universal**: `useTranslations` from next-intl in ~101 files; all copy in `messages/{en,fr}.json`. FR and EN are kept in **lockstep**.
+
+### Server / API conventions
+- Each route inlines `getServerSession(authOptions)` then a role gate (`role !== "admin"` → 403, etc.) and an inline ownership check. No `requireAuth` helper exists.
+- Concurrency safety = single-document atomic `findOneAndUpdate` "claims" (no multi-doc transactions). Idempotency via unique indexes (`StripeWebhookEvent.eventId`, per-appointment uniqueness) and dedup boolean flags.
+- Appointment dates are written via `parseAppointmentDate` (UTC-noon). Contact fields are AES-256-GCM encrypted via the Mongoose plugins.
+- Long-running side effects (email fan-out) are wrapped in `after()` so the serverless container stays alive for SMTP.
+
+---
+
+## (b) Target conventions for new code
+
+- **Strict TypeScript, no new `any`.** Type inputs/outputs at boundaries. Use `@ts-expect-error <reason>` (never `@ts-ignore`) only as a last resort. Don't add to the legacy `any` count.
+- **Validate at every trust boundary** — user input, network responses, stored data. Today there is no zod; for new non-trivial input validation, validate explicitly and return `400` with a clear shape on failure (mirror existing `ValidationError → 400` patterns). Never trust the client for role/ownership — check server-side.
+- **Keep components presentational; put logic in hooks/services.** Do not add to the god-files; extract new business logic into a `src/lib/*` module with a `*.spec.ts`, and call it from a thin route/handler. Prefer Server Components for new read-only pages where practical.
+- **No new module-level singletons for app state.** Local React state or a documented service; don't introduce a global mutable store ad hoc.
+- **Bilingual lockstep is mandatory**: every user-facing string lives in **both** `messages/en.json` and `messages/fr.json` under the same key. Thread `lang` into both `buildEmailHtml` and `buildEmailText` for emails. When i18n-ing a component whose styling matches message text, add an explicit `messageType` state.
+- **Accessible, designed empty/error/loading states** are part of scope for any new UI (the app hand-rolls these per page — follow the neighbouring page's pattern).
+- **Tests**: new logic gets a `*.spec.ts`; a bug fix gets a **failing regression test first**. Pure functions go in `src/lib`; route guards/handlers get a route spec (see existing `route.spec.ts` / `route.auth.spec.ts`). Money, auth, and routing changes are not "done" without a test.
+- **Money / state-machine changes**: respect the documented invariants (`cascadeAttempts` ≠ `refusedBy`; receipts only when `payment.status === "paid"`; `parseAppointmentDate` for dates; the encryption-hook ordering). See [debt-map](../quality/debt-map.md) and [CUJs](../product/critical-user-journeys.md).
+- **Conventional Commits**, one logical change per commit. Never weaken a gate to pass; propose gate changes separately.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,18 @@
+# Docs index
+
+The operating documentation for **Je chemine**. Start at [../AGENTS.md](../AGENTS.md) — it is the entry point for every session and links here. One fact has one home; if something is wrong, fix it where it lives (and see `/update-docs`).
+
+## Architecture
+- [architecture/overview.md](architecture/overview.md) — the system as it actually is: rendering/data-flow model, real directory layout, external services, entry points, and known deviations from a "target" architecture.
+- [architecture/decisions/0001-adopt-ai-operating-model.md](architecture/decisions/0001-adopt-ai-operating-model.md) — ADR-0001: adopt the AI operating model without migrating legacy code.
+
+## Conventions
+- [conventions/code-style.md](conventions/code-style.md) — (a) detected conventions as they exist today, and (b) target conventions for new code.
+
+## Quality
+- [quality/debt-map.md](quality/debt-map.md) — the honest, append-only map of landmines, fragile areas, missing test coverage, and deploy-coupled steps.
+
+## Product
+- [product/prd.md](product/prd.md) — the reverse-engineered PRD (problem, goals/non-goals, users, scope, metrics, open questions, decision log).
+- [product/overview.md](product/overview.md) — plain-language description of what the product does today, for a new teammate.
+- [product/critical-user-journeys.md](product/critical-user-journeys.md) — the journeys that must never break, with code locations and test coverage.

--- a/docs/product/critical-user-journeys.md
+++ b/docs/product/critical-user-journeys.md
@@ -1,0 +1,28 @@
+# Critical user journeys (CUJs)
+
+The flows that **must never break**. Inferred from the central routes and the matching/payment engines. Every row is **`[inferred — confirm]`** until the product owner confirms it.
+
+**Rule going forward:** a change that touches a CUJ must **verify that journey** (run it, or run/extend its tests) before claiming done — see [/verify](../../.claude/skills/verify/SKILL.md). A new user-visible feature must extend or register a CUJ here. "Test coverage" below is the *existing* automated coverage; **"none"** means manual verification is the only safety net, so be extra careful (see [debt-map](../quality/debt-map.md)).
+
+| ID | Journey | Steps (user's words) | Where it lives in code | Test coverage | Status |
+| --- | --- | --- | --- | --- | --- |
+| CUJ-1 | **Client intake → match** | "I pick who it's for, choose my reasons, submit — and get matched to a professional." | `src/app/appointment/page.tsx` → `POST /api/appointments` → `src/lib/appointment-routing.ts` (`routeAppointmentToProfessionals`) | matcher + cascade: `lib/appointment-routing.spec.ts`, `appointment-routing-gender.spec.ts`, `proposal-timeout.spec.ts`, `service-request.spec.ts`. **Route handler: none** | `[inferred — confirm]` |
+| CUJ-2 | **Guest booking + guest payment** | "Without an account, I book and pay through the link I was sent." | `src/app/appointment` (guest) → `POST /api/appointments/guest` → `src/app/pay/page.tsx` (`?token=`) → `api/payments/guest*` | **none** (all guest payment routes untested — debt-map P2) | `[inferred — confirm]` |
+| CUJ-3 | **Pro accepts a proposal / self-claims** | "I review the request and take the client (or pull one from the general pool)." | `src/app/(privilaged)/professional/dashboard/proposals/page.tsx` → `POST /api/appointments/[id]/accept` (+ `/refuse`) | cascade logic: `proposal-timeout.spec.ts`. **Accept/refuse routes: none** | `[inferred — confirm]` |
+| CUJ-4 | **Schedule → payment-method capture** | "My pro sets a date; I'm invited to add a payment method to confirm." | `POST /api/appointments/[id]/schedule-first` → payment-invitation email → `/pay` or `billing?action=addPaymentMethod` → SetupIntent | `client-payment-guarantee.spec.ts`, `client-portal-urls.spec.ts`. **Setup routes: none** | `[inferred — confirm]` |
+| CUJ-5 | **Session closure → charge → receipt** | "After my session I'm charged and get my official receipt." | `POST /api/appointments/[id]/complete-session` → `lib/session-closure.ts` (no-show billing) → `lib/stripe-off-session-charge.ts` / Interac → `issueFiscalReceipt` (`lib/session-post-closure.ts`) → receipt PDF | `complete-session/route.spec.ts`, `payment-settlement.spec.ts`, `session-post-closure.spec.ts`, `stripe-off-session-charge.spec.ts`, `pricing.spec.ts` ✅ | `[inferred — confirm]` |
+| CUJ-6 | **Stripe webhook settlement** | (system) "Payment confirms → mark paid, issue receipt, green the guarantee." | `src/app/api/payments/webhook/route.ts` → `lib/payment-settlement.ts` | **none** — the webhook itself is untested (debt-map **P1**); depends on LIVE event subscriptions | `[inferred — confirm]` |
+| CUJ-7 | **Professional payout** | "I get paid for my completed sessions." | `POST /api/stripe-connect/payout` and `api/admin/accounting/professionals/[id]/payout` → `ProfessionalLedgerEntry` debit | `stripe-connect/payout/route.spec.ts`, `admin/accounting/.../payout` spec ✅ | `[inferred — confirm]` |
+| CUJ-8 | **Signup → verify → login** | "I register, confirm my email, confirm my phone, then sign in." | `src/app/(auth)/signup/member` → `POST /api/auth/signup` → `(verify)/verify-account` (email link → SMS) → `(auth)/login` | `auth/account/verify-email/route.spec.ts`, `auth/forgot-password/route.spec.ts`. **Signup route (618 lines): none** | `[inferred — confirm]` |
+| CUJ-9 | **Account lifecycle (deactivate / RTBF)** | "I can deactivate my account or request permanent deletion." | settings pages → `POST /api/users/me/deactivate`, `POST /api/users/me/request-deletion` (admin alerted, financial data retained) | `users/me/deactivate` + `request-deletion` route specs ✅ | `[inferred — confirm]` |
+| CUJ-10 | **Internal messaging** | "I message my professional / support and get a reply." | `src/components/inbox/InboxView.tsx` → `api/messages/*` (allow-list in `lib/messaging-permissions.ts`) | `api/messages/messaging-security.spec.ts` ✅ | `[inferred — confirm]` |
+| CUJ-11 | **Admin triage queue** | "I assign, auto-match, release, or schedule a pending request." | `src/components/admin/RequestsQueueTable.tsx` → `api/admin/service-requests/[id]/{assign,approve,schedule}`, `/general-pool` | `service-requests/[id]/{assign,schedule}` specs; appointment `[id]` PATCH auth specs ✅ (partial) | `[inferred — confirm]` |
+| CUJ-12 | **Public content & legal pages render** | "I browse the library and read the terms/privacy pages." | `(public)/{explore,approaches,nouveautes,medias}/[slug]`, `(public)/{terms,privacy,cookies}` → `ContentEntry` / `LegalDocument` via `lib/legal-content.ts` | `legal-sections.spec.ts` (parse/serialize). **Page render: none** | `[inferred — confirm]` |
+
+## Highest-risk, least-covered (verify manually with extra care)
+
+- **CUJ-6 (Stripe webhook)** — untested and money-critical; also deploy-coupled to LIVE event subscriptions.
+- **CUJ-2 (guest payment)** — entirely untested money path.
+- **CUJ-1 / CUJ-8** — the matcher/cascade *logic* is well tested, but the booking and signup **route handlers** (the largest in the app) are not.
+
+When you touch any of these, run the relevant `pnpm test` specs **and** exercise the flow in a running app (`pnpm dev`), per [/verify](../../.claude/skills/verify/SKILL.md).

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -1,0 +1,36 @@
+# Product overview — what Je chemine does today
+
+Written for a new teammate. For *why* and scope/metrics see the [PRD](prd.md); for the flows that must never break see the [critical user journeys](critical-user-journeys.md).
+
+**Je chemine** (prod **www.jechemine.ca**) is a bilingual (French-first / English) Quebec online mental-health platform. It connects people who need mental-health support with vetted professionals, intelligently **matches** them, and then handles booking, payment, receipts, messaging, and professional payouts end to end. It is live and in production.
+
+## The main user flows
+
+**A client gets matched and seen.** A visitor lands on the marketing site, picks one of three intake personas — *for myself*, *for a loved one*, or *for a patient* (a physician/professional referral) — and fills a short funnel (`/appointment`) including 1–3 searchable "reasons for consultation" (motifs). No payment is asked for up front. Submitting creates a single **service request** (which is an `Appointment` record in a `pending` routing state). The **jumelage engine** scores active professionals and offers the request to the best fit; if they refuse or time out it cascades to a relaxed match, then to a general pool or the admin triage queue. A professional **accepts** (a match, not yet a time), then **schedules** a real date — which triggers a payment-method invitation. After the session, the professional **closes** it; the platform charges the saved card (or confirms an Interac transfer), issues a **fiscal receipt only once payment is confirmed**, and credits the professional's ledger.
+
+**A guest pays without an account.** Guests can book and pay via a tokenized link (`/pay?token=`) using Stripe Elements, and are later provisioned into a claimable account.
+
+**A professional runs their practice.** After signing up they wait for **admin approval** (they cannot enter the dashboard until approved). Once in, they see proposals (with accept SLAs — 24h regular / 12h emergency), can self-claim from the always-open general pool, manage their schedule and availability, complete sessions, see their billing/ledger, and message clients.
+
+**An admin operates the platform.** Admins triage the request queues ("Demande de service" and "Pool Général"), assign/auto-match/release requests, schedule on a pro's behalf, approve professionals, issue manual invoices and professional payouts, manage users and roles, edit the CMS / legal docs / email templates, and handle account reactivation and right-to-be-forgotten deletion requests.
+
+**Everyone communicates and learns.** Internal messaging links clients, their assigned professional, and support/admin (with a recipient allow-list). Public visitors browse a CMS-driven library of problématiques, treatments, news, and media.
+
+## Shipped capabilities (one paragraph each)
+
+- **Intelligent matching (jumelage).** A pure relevancy score over problematique, therapeutic approach, language, modality, availability, and a gender-preference bonus, with **hard filters only on age and stated gender preference** (so the pool rarely empties). A **3-level cascade** (strict → relaxed → admin queue) drives targeted offers; exhausted requests return to admins, never silently dropped. *(`src/lib/appointment-routing.ts`)*
+- **Intake & motif search.** Three standardized personas and a fuzzy, accent-insensitive multi-select reason search (1–3 motifs) that feeds the matcher; motifs are validated against a live bilingual taxonomy. *(`src/components/ui/MotifSearch.tsx`, `src/models/Motif.ts`)*
+- **Booking & scheduling.** A multi-step funnel for guests and members, plus emergency ("quick one-time consultation") and change-professional variants; admin and pro can schedule, edit, and drag-drop in their agenda. *(`src/app/appointment`, `src/app/(privilaged)/*`)*
+- **Payments & billing.** Stripe card + ACSS/PAD charged off-session after the session, or **Interac** transfers confirmed by an admin; manual admin invoicing from the schedule; **receipts strictly gated on confirmed payment** with unique invoice numbers; no-show / late-cancel management fees at 100%; **manual professional payouts** via Stripe Connect transfers (to avoid per-charge fees). *(`src/lib/payment-settlement.ts`, `session-post-closure.ts`, `api/stripe-connect/payout`)*
+- **Internal messaging.** Allow-listed conversations (client ↔ assigned pro ↔ support), near-real-time via polling, with peer-visibility controls for professionals. *(`src/lib/messaging-permissions.ts`)*
+- **Editorial CMS.** A unified content model powering the public library (problématiques, traitements, nouveautés, médias) plus FAQ, legal documents, and editable transactional email templates — all bilingual, Tiptap-edited, with images stored in MongoDB. *(`src/models/ContentEntry.ts`, `EmailTemplate.ts`, `LegalDocument.ts`)*
+- **Admin operations.** Role hierarchy with granular permissions, professional approval, request triage, accounting ledger, account reactivation/deactivation, Loi 25 right-to-be-forgotten deletion requests, and platform settings. *(`src/app/(privilaged)/admin`, `src/models/Admin.ts`)*
+
+## Integrations that power it
+
+- **MongoDB Atlas** — all data, plus binary uploads stored as BSON `Buffer`s (Vercel's filesystem is read-only).
+- **Stripe 19 + Stripe Connect** — payments (separate charges & transfers; the platform holds the float), guest payments, ACSS/PAD mandates, refunds/disputes via a signed, idempotent webhook.
+- **Nodemailer SMTP** — all ~45 transactional emails (fail-soft), built by one bilingual builder and backed by an admin-editable template registry.
+- **Twilio** — SMS for phone verification and payment-request reminders (best-effort).
+- **next-intl** — bilingual FR/EN, cookie-driven (no locale in the URL).
+- **Vercel Cron + in-app lazy trigger** — daily reminder crons (`vercel.json`); the time-sensitive matching cascade advances via an in-app "lazy cron" off dashboard traffic (`lib/lazy-cron.ts`), with an optional external pinger as a 24/7 backstop.

--- a/docs/product/prd.md
+++ b/docs/product/prd.md
@@ -1,0 +1,64 @@
+# PRD — Je chemine (reverse-engineered)
+
+> Reverse-engineered from the codebase on **2026-06-20**, with goals/non-goals/metrics/scope confirmed by the product owner. Every claim is **observed** (with a source) or **`[inferred]`**. Unknowns are Open Questions, not assumptions.
+
+## Problem & opportunity
+
+In Quebec, access to mental-health care is slowed by long waitlists and the friction of finding a professional who fits a person's specific needs, language, age group, modality, and availability. **Je chemine** positions itself as a bilingual "Plateforme de santé mentale™ / Integrated Health Platform™" that removes that friction with an **intelligent matching (jumelage) engine** plus an end-to-end path from intake to a paid, completed session — *"Quick access to qualified professionals… without long waiting lists"* and *"an intelligent matching system to guide you to the professional that suits you best."* *(observed: messages/en.json HeroSection/ClientAdvantagesSection; README.md goal statement)*
+
+## Goals & non-goals
+
+**Primary goal (confirmed):** **Faster matching** — reduce the time and effort from intake to an accepted match / first scheduled appointment. The jumelage engine is the flagged P0 differentiator. *(confirmed by product owner; observed P0 in TODO.md)*
+
+**Secondary goals (confirmed, ranked):** more paid completed sessions; grow & retain professional supply; expand the B2B (schools/EAP) funnels. *(confirmed)*
+
+**Non-goals (confirmed — Je chemine deliberately is NOT):**
+- **A crisis/emergency service.** The `/emergency` flow is a "Consultation ponctuelle rapide", not a 24/7 crisis line; it disclaims and defers to 911 / 988 / 1-866-APPELLE. *(observed: src/app/(public)/emergency/page.tsx; messages EmergencyAppointment)*
+- **A clinical EHR.** It captures intake (`MedicalProfile`) and session-act notes, not full electronic health records / clinical charting. *(confirmed; observed model scope)*
+- **An insurance/RAMQ biller.** Clients pay the platform (Stripe/Interac) and claim with their insurer themselves; the platform does not bill public/private insurers. *(confirmed)*
+- **A full B2B portal product.** Schools (Sentiers) and enterprise/EAP are **lead-capture forms only**, not self-serve portals. *(confirmed; observed: school-manager & enterprise/contact routes are contact-only)*
+
+## Users & jobs
+
+- **Clients / members** — three standardized intake personas: **"For myself"** (individual adult), **"For a loved one"** (child/spouse/etc.), **"For a patient"** (physician/professional referral). Job: *"find and book the right professional for me or someone I care for, fast, in my language."* Minors are handled via a **guardian / account-manager** model gated by the **Quebec LSSSS art. 14** age-14 rule (under-14 uses the parent's email; 14+ uses their own). *(observed: messages HeroSection forSelf/forLovedOne/forPatient; src/app/appointment/page.tsx; src/models/User.ts guardianId)*
+- **Professionals / therapists** (psychologists, neuropsychologists, psychotherapists, psychoeducators, OTs in mental health, psychiatrists) — *"focus on people; let the platform handle scheduling, billing, payout, and matching."* They accept targeted proposals or self-claim from the general pool. *(observed: messages Professional*; src/app/(privilaged)/professional)*
+- **Employees / admins** (role hierarchy `super_admin` → `platform/content/support/billing_admin` → `employee`) — run intake triage/routing, manual invoicing, professional payouts, the CMS, and account lifecycle. *(observed: src/models/Admin.ts; admin dashboard)*
+- **Schools & enterprises** (B2B leads) — submit a school-service request (Sentiers: evaluation / ADHD / intervention plan) or an enterprise/EAP enquiry. Job: *"get a quote / be contacted."* *(observed: school-manager & enterprise contact forms)*
+
+## Current scope (shipped capabilities, ranked by centrality)
+
+1. **Intelligent matching / jumelage** — `lib/appointment-routing.ts`: weighted relevancy score (problematique, approach, language, modality, availability, gender bonus) with **hard filters only on age and stated gender preference**, and a **3-level refusal cascade** (strict score ≥ 100 → relaxed ≥ 20 → admin queue). The differentiator. *(observed)*
+2. **Intake with a search-based motif engine** — 1–3 selectable "reasons for consultation" feeding the matcher (`MotifSearch`, `useMotifSearch`, `Motif` model). *(observed; P0 in TODO.md)*
+3. **Booking & scheduling** — 3-persona funnel for guests and members, including emergency and change-professional variants; `Appointment` doubles as the service-request record. *(observed: src/app/appointment, src/models/Appointment.ts)*
+4. **Payments & billing** — Stripe card + ACSS/PAD (off-session charge after the session) and **Interac** (out-of-band, admin-confirmed); manual admin invoicing; **fiscal receipts gated on confirmed payment** (golden rule); **manual professional payouts** via Connect transfers to avoid Stripe fees; no-show / late-cancel "Frais de gestion de dossier" billed at 100%. *(observed: lib/payment-settlement, session-post-closure, stripe-connect/payout; RAPPORT-FEEDBACK-JUIN-2026.md §4–6)*
+5. **Internal messaging** — client ↔ assigned pro ↔ support/admin, with a recipient allow-list and 10s polling. *(observed: lib/messaging-permissions, InboxView)*
+6. **Editorial / educational CMS** — `ContentEntry` (problématiques, traitements, nouveautés, médias), legal documents, FAQ, motifs, resources/library; Tiptap editor; images stored in Mongo. *(observed: src/models/ContentEntry.ts; admin content pages)*
+7. **Admin operations** — user/role management, account reactivation/deactivation, right-to-be-forgotten deletion requests, accounting ledger, reports, platform settings, editable email templates. *(observed: admin dashboard + RAPPORT §1–2,9)*
+
+## Constraints
+
+- **Regulatory (Quebec)**: Loi 25 / Bill 25 compliance, data hosted in Canada, end-to-end encryption, mandatory 2FA, LSSSS art. 14 (minors), RGPD-style right-to-be-forgotten **with mandatory retention of invoices/financial data**, consent/terms versioning. *(observed: messages trust icons; src/models/AdminAccessLog.ts, AuthAuditLog.ts; request-deletion route)*
+- **Technical**: in-production on Vercel (read-only FS → binaries stored in Mongo); no multi-doc transactions (atomic single-doc claims); JWT sessions go stale until re-login; fail-soft email/SMS; **no CI test gate** (see [debt-map](../quality/debt-map.md)).
+- **Commercial**: separate-charges-and-transfers Stripe model — the platform holds the float and pays pros manually. *(observed: api/stripe-connect/payout)*
+
+## Success metrics (confirmed — the ones the PRD tracks)
+
+1. **Time to match** — intake → accepted match / first scheduled appointment.
+2. **Proposal acceptance rate** — share of proposals pros accept before the cascade falls back to the admin queue (`cascadeAttempts`, `awaiting_admin`).
+3. **Booking → paid conversion** — share of intakes that become paid, completed sessions (`payment.status === "paid"`, `fiscalReceiptIssuedAt`).
+4. **Professional utilization & retention** — active pros, caseload fill, `acceptingNewClients` rates, churn.
+
+*Targets are not yet committed — marketing copy's "95% satisfaction" / "24/7 support" are claims, not measured signals. See Open Questions.* `[inferred]` that the data to compute these exists in `Appointment`/`User`/ledger but no analytics pipeline was found.
+
+## Open questions
+
+- What numeric **targets/SLAs** back each metric (acceptable time-to-match, target acceptance rate, conversion benchmark)? None are committed in code.
+- Is the **LIVE Stripe webhook** subscribed to all required events (`setup_intent.succeeded`, `charge.dispute.created`, `charge.refund.updated`)? *(debt-map P1)*
+- Will **Sentiers (schools)** and **enterprise/EAP** ever become full portals, or remain lead-capture? (Confirmed lead-capture *for now*.)
+- **International expansion** is the stated long-term scope — what triggers it, and what changes (multi-currency, beyond Loi 25/LSSSS, languages beyond FR/EN)? Today everything is Quebec/CAD/FR-first.
+- Are the marketing claims (satisfaction %, professional perks like the investment fund / shareholding) commercially committed, or aspirational copy? Commercial terms live in an external collaboration agreement, not the code.
+- Is the **booking-time acknowledgement email** still desired, or redundant now that the jumelage email is the first real client touch? *(flagged in audit)*
+
+## Decision log
+
+- **2026-06-20** — PRD reverse-engineered from the codebase; goals (primary: faster matching), non-goals (all four), success metrics (all four), and market scope (Quebec now, international later) **confirmed by the product owner**. Pending broader product-owner review of targets/SLAs and the Open Questions above.

--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -1,0 +1,57 @@
+# Debt map
+
+The honest map of landmines, fragile areas, missing coverage, and deploy-coupled steps in **Je chemine**. **This file is append-only**: future sessions *add* findings here (with a date) instead of fixing-by-the-way. Before a non-trivial change, check whether you're about to touch something on this list.
+
+Severity: **P1** = can lose money / data / security now · **P2** = real risk, handle with care · **P3** = cruft / hygiene.
+
+## Security & production landmines
+
+- **[P1] Weak super-admin in the real DB.** `admin@admin.com` / `admin123` (full super-admin) is reported to exist in the production database (`RAPPORT-FEEDBACK-JUIN-2026.md` → "Points d'attention" #1). Must be changed/removed before/at production. *(observed: RAPPORT-FEEDBACK-JUIN-2026.md)*
+- **[P2] `/api/files/[id]` coarse authorization.** Any signed-in user can fetch any non-`content-image` `StoredFile` by ObjectId (incl. patient referral PDFs, employee CVs, payout cheques). `content-image` is fully public. Security relies on consumer endpoints never leaking ids + ObjectId unguessability. The same route has a **BSON-Binary empty-body trap** (`.length` is a method on lean Binary) — keep the manual `Buffer.from(binary.buffer)` normalize branch. *(src/app/api/files/[id]/route.ts)*
+- **[P2] In-memory rate limiting.** `lib/rate-limit.ts` is a per-process map (signup, forgot-password); it does not span serverless instances and resets on cold start — weak brute-force protection. No Redis/Upstash. *(src/lib/rate-limit.ts)*
+- **[P2] Field encryption is key-coupled.** AES-256-GCM via `FIELD_ENCRYPTION_KEY` with a `v1.` envelope. Misconfiguring/rotating the key makes existing ciphertext undecryptable and breaks off-session charging (`MISSING_PAYMENT_METHOD`). *(src/lib/mongoose-contact-encryption.ts)*
+- **[P2] Encryption-hook ordering.** The `User` pre-save lookup-hash hook (`phoneLookupHash`) **must** run before the contact-encryption plugin (phone must still be plaintext). Reordering silently corrupts dedup. *(src/models/User.ts)*
+
+## Money & state-machine fragility (test before touching)
+
+- **[P1] Stripe webhook is untested.** `src/app/api/payments/webhook/route.ts` (~510 lines: payment success/fail/cancel, full/partial refund with receipt void/restore, dispute, `setup_intent.succeeded`) has **no spec** — the single most consequential payment integration point. Add tests before editing. *(observed: no matching spec)*
+- **[P1] LIVE Stripe webhook event subscriptions.** Receipt issuance, dispute flagging, refund reversal, and ACSS guarantee-green depend on the **LIVE** endpoint subscribing to `payment_intent.succeeded`, `setup_intent.succeeded`, `charge.dispute.created`, `charge.refund.updated`. Memory notes TEST is configured; **LIVE may be missing** the latter three. `scripts/add-stripe-webhook-events.ts` exists to help. *(deploy-coupled)*
+- **[P2] `complete-session` charges money + closes billing.** `appointments/[id]/complete-session/route.ts` runs the off-session Stripe charge and finalizes billing, guarded only by an atomic `sessionCompletedAt: null` claim + Stripe idempotency key; the catch rolls back only if `!closureFinalized`. Subtle ordering — a careless edit can double-charge or strand a closure. *(has a route spec — keep it green)*
+- **[P2] `cascadeAttempts` vs `refusedBy`.** The cascade counter is deliberately distinct from the never-re-propose set (release/reassign also write `refusedBy`). **Never derive cascade progress from `refusedBy.length`** — it breaks the cascade. *(src/models/Appointment.ts, src/lib/appointment-routing.ts)*
+- **[P2] Matcher can overwrite an in-flight admin assignment.** Re-routing on refusal/timeout is defended only by `commitRouting`'s filter (`routingStatus: pending` + `professionalId` absent). Any new write path that ignores this filter resurrects the silent-overwrite bug. *(src/lib/appointment-routing.ts)*
+- **[P2] Payout route holds real-money logic inline.** `stripe-connect/payout/route.ts`: SHA256 idempotency, atomic row-claim via `updateMany`, Connect onboarding verification, Interac-exclusion. Best-effort ledger write means a transfer can succeed while the ledger debit silently fails. *(has a route spec)*
+- **[P2] No multi-document transactions.** `account-merge.ts` re-points ~15 collections then deletes the loser last (designed re-runnable, but a crash mid-merge leaves partially re-pointed data). All consistency is single-doc atomic claims. *(src/lib/account-merge.ts)*
+- **[P2] Legacy UTC-midnight appointment rows.** `parseAppointmentDate` now anchors at UTC-noon, but rows written before the fix were **never backfilled** — date math on old rows can still render a day early. *(memory; no backfill run)*
+- **[P3] `renderTemplate` silently drops unknown tokens.** Admin email-template typos substitute to empty (not literal); conditionals are regex with a 6-pass cap (deeply nested sections can under-render). *(src/lib/notifications.ts)*
+
+## Testing & CI gaps
+
+- **[P1] No CI quality gate.** There are **no GitHub Actions workflows** at all. **Nothing runs `vitest`, `lint`, `tsc`, or `knip` in CI.** The Vercel `next build` enforces the strict **TypeScript** typecheck but **not** ESLint (Next 16 doesn't run lint at build) and **not** failing tests — so a logically-broken-but-compiling change ships. Run `pnpm test` yourself. *(.github/workflows/, package.json; verified 2026-06-20: `pnpm build` exits 0 with 84 open lint errors)*
+- **[P2] `pnpm lint` does not pass.** The tree has **~84 pre-existing ESLint errors** (+49 warnings), mostly `@typescript-eslint/no-explicit-any` (e.g. `admin/admins/*` routes, `lib/api-client.ts`, `lib/auth.ts`, `lib/mongodb.ts`), plus React-Compiler rules (`react-hooks/purity` on `Date.now()` in `client/dashboard/page.tsx` + `useInactivityLogout.ts`, `react-hooks/set-state-in-effect`, `react-hooks/rules-of-hooks` in `professional/dashboard/page.tsx`) and `react/no-unescaped-entities`. Because `next build` doesn't run ESLint, these don't block deploys — but it means **lint is advisory**: don't add new errors; a clean lint run is a separate, deliberate cleanup effort. *(observed: `pnpm lint` → 84 errors / 49 warnings on 2026-06-20)*
+- **[P2] Large untested critical paths.** No spec for: the Stripe webhook, `payments/create-intent` / `setup-intent` / `payment-methods` / all **guest payment** routes, the 815-line `appointments/route.ts` (main booking), the 618-line `auth/signup/route.ts`, `stripe-connect/create-account`, and any cron route end-to-end. **Zero UI/component tests** (vitest runs in node env; TODO.md asked for form/integration tests that were never written). ~118 of ~154 routes have no spec. *(observed)*
+
+## Cruft & hygiene
+
+- **[P3] Three committed lockfiles.** `bun.lock` + `package-lock.json` + `pnpm-lock.yaml` all tracked; **pnpm is canonical**. The stale two invite wrong-installer drift. Confirm the Vercel build installs via pnpm. *(repo root)*
+- **[P3] Stray committed artifact.** A file literally named `c:tmpnext-dev.log` (a Windows path used as a redirect target, containing a Turbopack FATAL panic) is committed at repo root. Pure cruft — safe to delete. *(repo root, .gitignore doesn't cover it)*
+- **[P3] Broken `seed` script.** `package.json` declares `"seed": "tsx src/lib/seed.ts"` but `src/lib/seed.ts` does not exist — `pnpm seed` fails. (`seed-motifs`, `reset-motifs`, `create-admin`, `seed-routing-test` are real.) *(package.json)*
+- **[P3] God-files.** `lib/notifications.ts` (~6.7k lines), `email-template-registry.ts` (~3k), `app/appointment/page.tsx` (~3.1k), `MedicalProfile.tsx` (~2.2k), `signup/member` (~2.1k), `proposals` page (~1.5k). Edit surgically; don't rewrite without a plan + tests.
+- **[P3] ~91 `any` + 82 `console.log`** in `src` (hotspots: `admin/admins/*` routes, `lib/api-client.ts`, `seed-routing-test.ts`, `notifications.ts`, `webhook`). 23 inline `eslint-disable` (mostly `no-img-element`).
+- **[P3] Duplicate/parallel systems** (don't add a third): `Problematique` vs `ContentEntry` CMS; `PlatformSettings.emailSettings.templates` vs `EmailTemplate`; `StoredFile` vs `ClientDocument`; `guardianId` vs `accountManagerId`; `issueType` vs `needs[]`. *(src/models)*
+- **[P3] Orphaned design tokens / fonts.** `src/theme.ts` (indigo/purple) and `src/config/colors.ts` don't match the live OKLCH palette in `globals.css`; `globals.css` references undefined `--font-*` vars (no `next/font` loaded → system-font fallback). Editing the wrong source does nothing visible.
+- **[P3] Dead dependency.** `react-select` (+ `@types/react-select`) is installed but never imported. `pnpm prune` (knip) will flag it.
+- **[P3] `Resource`/`ResourcePurchase` default to `usd`** while the platform is CAD — the marketplace appears unused/abandoned. *(src/models/Resource.ts)*
+
+## Deploy-coupled manual steps (no automation — easy to forget)
+
+- Stripe **LIVE** webhook must subscribe to the 4 events above.
+- `scripts/backfill-post-meeting-reminder-flag.ts` must be run once, or the post-meeting collection cron can mass-mail historical clients (mitigated only by a 14-day lookback).
+- Stale `jumelageSuccess` `EmailTemplate` rows (fr+en) must be deleted so they re-seed corrected (per memory).
+- `MAIL_FROM` must equal `SMTP_USER` (or a verified Gmail "Send mail as" alias) or Gmail rewrites/rejects mail; `CRON_SECRET` must be set or all 5 crons 401.
+- A squash-merge to `main` sometimes does not trigger the Vercel build — push an empty commit to re-trigger.
+
+---
+
+## Findings log (append below, dated)
+
+- **2026-06-20** — Debt map created from the initial codebase audit. Items above are the baseline. Add new findings here with a date and a `[P#]` severity instead of fixing legacy code in passing.


### PR DESCRIPTION
Commit the previously-untracked AI operating-model scaffold (AGENTS.md / CLAUDE.md operating manual, `docs/`, `.claude/skills/`), including the cron-doc sync from the GitHub-Actions removal. Docs-only — no app/runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)